### PR TITLE
Use Theme.Holo when running on ICS

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,7 +3,7 @@
       package="hu.vsza.adsdroid"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="9" />
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="14" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application android:label="@string/app_name" android:icon="@drawable/icon">


### PR DESCRIPTION
I changed one line in AndroidManifest.xml so the app uses the new Holo theme when running on Android 4.0. It should work normally on other android versions and just use the old theme.
